### PR TITLE
remove name prefix

### DIFF
--- a/app/views/test_reports/_detail_table.html.slim
+++ b/app/views/test_reports/_detail_table.html.slim
@@ -25,7 +25,7 @@
         - file_path = ftc.file_path
         tr
           td
-            = form_with scope: :update, url: "result/#{ftc.result_id}", local: false do |f|
+            = form_with url: "result/#{ftc.result_id}", local: false do |f|
               ul
                 = f.hidden_field :job_id, value: job.id
                 = f.hidden_field :round, value: round


### PR DESCRIPTION
Fix the bug for wrong parameter name.

When using "scope", parameter name will get the prefix.

EX:
```
# form_with scope: :update
name=update[round]
```

```
# form_with
name=round
```

* The reason why it didn't happen before is because the scope was typo and the prefix was not enable.