### PR TITLE
delete unused elements

### DIFF
--- a/app/models/test_suite.rb
+++ b/app/models/test_suite.rb
@@ -17,4 +17,8 @@
 
 class TestSuite < ApplicationRecord
   has_many :test_cases, dependent: :destroy
+
+  def self.ransackable_attributes(_auth_object = nil)
+    ['id']
+  end
 end

--- a/app/views/test_reports/_detail_table.html.slim
+++ b/app/views/test_reports/_detail_table.html.slim
@@ -6,19 +6,11 @@
         th[scope="cols"]
           | Check Status
         th[scope="cols"]
-          | Priority
-        th[scope="cols"]
-          | Suite Name
-        th[scope="cols"]
-          | Suite Description
-        th[scope="cols"]
           | Case Name
         th[scope="cols"]
           | Case Description
         th.error-message[scope="cols"]
           | Error Message
-        th[scope="cols"]
-          | Elappsed Time(s)
     tbody
       - data_for_test_reports[:failed_test_cases].each do |ftc|
         - base_url = ftc.github_url
@@ -34,12 +26,6 @@
                 li
                   = text_area_tag 'check_comment', ftc.check_comment, size: "30x5", required: true, onblur: 'Rails.fire(this.form, "submit")', placeholder: 'Leave your comment here'
           td
-            = ftc.priority
-          td
-            = link_to ftc.test_suite_name, test_suite_path(ftc.test_suite_id)
-          td
-            = ftc.suite_description
-          td
             = link_to ftc.case_name, base_url << file_path, target: '_blank'
           td
             div.case-description
@@ -47,5 +33,3 @@
           td
             div.error-message
               = ftc.error_title
-          td
-            = ftc.elapsed_time

--- a/app/views/test_reports/show.html.slim
+++ b/app/views/test_reports/show.html.slim
@@ -79,27 +79,15 @@ p
     thead
       tr
         th[scope="cols"]
-          | Suite Name
-        th.long[scope="cols"]
-          | Suite Description
-        th[scope="cols"]
           | Case Name
         th.long[scope="cols"]
           | Case Description
-        th[scope="cols"]
-          | Elappsed Time(s)
     tbody
       - @data_for_test_reports[:slow_time_test_cases].each do |s|
         - base_url = s.github_url
         - file_path = s.file_path
         tr
           td
-            = link_to s.test_suite_name, test_suite_path(s.test_suite_id)
-          td.long
-            = s.suite_description
-          td
             = link_to s.case_name, base_url << file_path, target: '_blank'
           td.long
             = s.case_description
-          td
-            = s.elapsed_time


### PR DESCRIPTION
## What I did
### I deleted some elements because in our project, we rarely use these elements below

- suite name
- suite desc
  - we only use 'case name' and 'case desc', and seldom use 'suite name' and 'suite desc'.
- priority 
- elapped time

### I executed rubocop

-  I have nothing to fix.

