### PR TITLE
fix: Dockerイメージビルド時にアセットをプリコンパイルするよう修正

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 Gemfile.lock
 docker
 docker-*
+!docker-entrypoint.sh
 log
 node_modules
 tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,16 @@ RUN \
   bundle install && \
   rm -rf ~/.gem
 
-CMD bundle exec rake assets:precompile RAILS_ENV=${RAILS_ENV}
+# Asset precompilation (skip webpacker as it's not used in this app)
+RUN WEBPACKER_PRECOMPILE=false bundle exec rake assets:precompile RAILS_ENV=${RAILS_ENV}
+
+# Copy assets to assets-image for volume sync on startup
+# (Volume mounts override /app/public/assets, so we keep a copy)
+RUN cp -r /app/public/assets /app/public/assets-image
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 3000
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb", "config.ru"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - ./tmp/:/app/tmp
       - ./log/:/app/log
+      - assets:/app/public/assets
     environment:
       - TZ=${TZ}
       - RAILS_ENV=${RAILS_ENV:-production}
@@ -27,9 +28,13 @@ services:
     volumes:
       - ./public/:/app/public
       - ./tmp/:/app/tmp
+      - assets:/app/public/assets:ro
     environment:
       - TZ=${TZ}
     ports:
       - 80:80
     depends_on:
       - app
+
+volumes:
+  assets:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Sync precompiled assets from image to volume
+# This ensures the volume always has the latest assets after rebuild
+if [ -d /app/public/assets-image ]; then
+  echo "Syncing assets from image to volume..."
+
+  # Remove old files including hidden files (e.g., .sprockets-manifest-*.json)
+  find /app/public/assets -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+
+  # Copy all files including hidden files
+  cp -a /app/public/assets-image/. /app/public/assets/
+
+  echo "Assets sync completed."
+fi
+
+# Execute the main command
+exec "$@"


### PR DESCRIPTION
## 変更点サマリ:
- assets:precompileをCMDからRUNに変更（ビルド時に実行）
- WEBPACKER_PRECOMPILE=falseを設定（Webpacker未使用のため）
- Named Volume (assets) でapp/web間のassets共有を実現
- エントリーポイントで起動時にassetsをVolumeへ同期（再ビルド対応）
- CMD定義を追加（Puma起動）

これにより、application.cssがDockerイメージに含まれ、
Nginxからも正しく配信されるようになります。
再ビルド後も最新のassetsが配信されます。

以下修正内容詳細：
## 概要

コンテナ起動時に `application.css` が見つからずエラーになる問題を修正。

## 問題

```
ActionView::Template::Error: The asset "application.css" is not present in the asset pipeline.
```

**原因**: Dockerfile で `CMD` としてプリコンパイルを定義していたが、docker-compose.yml の `command` で上書きされ、プリコンパイルが実行されなかった。

## 解決策

ビルド時にプリコンパイルを実行し、Named Volume で app/web 間で共有。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `Dockerfile` | `CMD` → `RUN` でプリコンパイル、ENTRYPOINT/CMD 追加 |
| `docker-compose.yml` | Named Volume `assets` を定義・マウント |
| `docker-entrypoint.sh` | 起動時に assets を Volume へ同期（新規） |
| `.dockerignore` | `docker-entrypoint.sh` を除外対象から外す |

## 動作の流れ

```
ビルド時:
  rake assets:precompile → /app/public/assets/ に生成
                        → /app/public/assets-image/ にコピー（バックアップ）

起動時 (docker-entrypoint.sh):
  assets-image/ → assets/ (Volume) へ同期
  ※ 古いファイルを削除してから最新をコピー

実行時:
  app コンテナ: Volume をマウント
  web コンテナ: 同じ Volume を読み取り専用でマウント
  → Nginx から CSS/JS が正しく配信される
```

## 主な変更点

### 1. プリコンパイルをビルド時に実行

```diff
-CMD bundle exec rake assets:precompile RAILS_ENV=${RAILS_ENV}
+RUN WEBPACKER_PRECOMPILE=false bundle exec rake assets:precompile RAILS_ENV=${RAILS_ENV}
```

- `WEBPACKER_PRECOMPILE=false`: Webpacker は未使用のためスキップ（Sprockets のみ使用）
- Node.js/npm/yarn は不要（Sprockets は Ruby のみで動作）

### 2. Named Volume で assets 共有

```yaml
volumes:
  assets:

services:
  app:
    volumes:
      - assets:/app/public/assets
  web:
    volumes:
      - assets:/app/public/assets:ro
```

### 3. 起動時同期（再ビルド対応）

Named Volume は初回のみイメージ内容で初期化されるため、エントリーポイントで毎回同期。

```bash
# 古いファイル（隠しファイル含む）を削除
find /app/public/assets -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
# 新しいファイル（隠しファイル含む）をコピー
cp -a /app/public/assets-image/. /app/public/assets/
```

### 4. ENTRYPOINT/CMD の追加

```dockerfile
ENTRYPOINT ["docker-entrypoint.sh"]
CMD ["bundle", "exec", "puma", "-C", "config/puma.rb", "config.ru"]
```

- 元の Dockerfile は CMD 削除後、ベースイメージの `irb` が復活する状態だった
- Puma 起動を明示的に定義

## 検証項目

- [x] ローカルで `docker build` 成功
- [x] `application-*.css` がイメージ内に生成される
- [x] `.sprockets-manifest-*.json` が正しく同期される
- [x] 再ビルド後も最新の assets が配信される
- [x] `git diff --check` でエラーなし

## 補足

- **Webpacker gem は存在するが未使用**: `javascript_pack_tag` / `stylesheet_pack_tag` の使用なし
- **Sprockets のみ使用**: `stylesheet_link_tag` / `javascript_include_tag` のみ
